### PR TITLE
Replace Newtonsoft.Json with custom PKM serializer

### DIFF
--- a/PKMRaw/PKMRaw.csproj
+++ b/PKMRaw/PKMRaw.csproj
@@ -29,7 +29,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="PKHeX.Core" Version="24.11.11" />
 	</ItemGroup>
 

--- a/PKMRaw/RawViewer.cs
+++ b/PKMRaw/RawViewer.cs
@@ -1,6 +1,6 @@
-﻿using Newtonsoft.Json;
-using PKHeX.Core;
+﻿using PKHeX.Core;
 using System.Text;
+using System.Reflection;
 
 namespace PKMRaw;
 
@@ -18,10 +18,8 @@ public partial class RawViewer : Form
     public RawViewer(PKM pokéMon)
     {
         InitializeComponent();
-
         Text = GetWindowText(pokéMon);
-
-        pkmRawTextBox.Text = JsonConvert.SerializeObject(pokéMon, Formatting.Indented);
+        pkmRawTextBox.Text = SerializePKM(pokéMon);
     }
     #endregion
 
@@ -29,13 +27,69 @@ public partial class RawViewer : Form
     private static string GetWindowText(PKM pokéMon)
     {
         var builder = new StringBuilder();
-
         if (!string.IsNullOrWhiteSpace(pokéMon.Nickname))
             builder.Append(pokéMon.Nickname).Append(' ');
-
         builder.Append(pokéMon.PID);
-
         return builder.ToString();
+    }
+
+    private static string SerializePKM(PKM pkm)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("{");
+
+        // Get all readable properties
+        var properties = pkm.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead);
+
+        var lastProp = properties.Last();
+        foreach (var prop in properties)
+        {
+            try
+            {
+                var value = prop.GetValue(pkm);
+                var valueStr = FormatValue(value, prop.PropertyType);
+
+                builder.Append($"  \"{prop.Name}\": {valueStr}");
+
+                // Add comma if not the last property
+                if (prop != lastProp)
+                    builder.AppendLine(",");
+                else
+                    builder.AppendLine();
+            }
+            catch
+            {
+                // Skip properties that can't be read or serialized
+                continue;
+            }
+        }
+
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static string FormatValue(object? value, Type propertyType)
+    {
+        if (value == null)
+            return "null";
+
+        // Handle span types
+        if (propertyType == typeof(ReadOnlySpan<byte>))
+            return "[bytes...]";
+        if (propertyType == typeof(ReadOnlySpan<ushort>))
+            return "[ushorts...]";
+
+        return value switch
+        {
+            string str => $"\"{str}\"",
+            bool b => b.ToString().ToLowerInvariant(),
+            DateTime dt => $"\"{dt:yyyy-MM-dd HH:mm:ss}\"",
+            IEnumerable<byte> bytes => $"[{string.Join(", ", bytes)}]",
+            Array arr => $"[{string.Join(", ", arr.Cast<object>())}]",
+            _ => value.ToString() ?? "null"
+        };
     }
     #endregion
 }

--- a/PKMRaw/RawViewer.resx
+++ b/PKMRaw/RawViewer.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema
+    Microsoft ResX Schema 
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter


### PR DESCRIPTION
## Changes
- Removed Newtonsoft.Json dependency
- Implemented custom PKM property serialization to handle ReadOnlySpan and other complex types
- Refactored RawViewer to use direct property inspection and formatting
- Removed unused Json reference from PkmRawPlugin.cs

## Why
- Eliminates external dependency requirement
- Fixes FileNotFoundException issues with Newtonsoft.Json loading
- Better handles PKHeX-specific data types like ReadOnlySpan<byte>

## Testing
- Verified PKM data display in RawViewer
- Confirmed all visible properties are correctly formatted