### PR TITLE
Add Search Feature

### DIFF
--- a/PKMRaw/RawViewer.Designer.cs
+++ b/PKMRaw/RawViewer.Designer.cs
@@ -1,11 +1,29 @@
 ﻿namespace PKMRaw;
 
+/// <summary>
+/// Partial class containing the Windows Forms designer generated code for the RawViewer form.
+/// </summary>
 partial class RawViewer
 {
     /// <summary>
     /// Required designer variable.
     /// </summary>
     private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    /// The search box text input control.
+    /// </summary>
+    private TextBox searchBox;
+
+    /// <summary>
+    /// The search button control.
+    /// </summary>
+    private Button searchButton;
+
+    /// <summary>
+    /// The label for the search box.
+    /// </summary>
+    private Label searchLabel;
 
     /// <summary>
     /// Clean up any resources being used.
@@ -20,34 +38,54 @@ partial class RawViewer
         base.Dispose(disposing);
     }
 
-    #region Windows Form Designer generated code
-
     /// <summary>
     /// Required method for Designer support - do not modify
     /// the contents of this method with the code editor.
     /// </summary>
     private void InitializeComponent()
     {
-        var resources = new System.ComponentModel.ComponentResourceManager(typeof(RawViewer));
+        System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RawViewer));
+
+        // Search Label
+        searchLabel = new Label();
+        searchLabel.Location = new Point(12, 15);
+        searchLabel.Size = new Size(50, 23);
+        searchLabel.Text = "Search:";
+        searchLabel.AutoSize = true;
+
+        // Search Box
+        searchBox = new TextBox();
+        searchBox.Location = new Point(65, 12);
+        searchBox.Size = new Size(200, 23);
+        searchBox.Name = "searchBox";
+        searchBox.KeyPress += SearchBox_KeyPress;
+
+        // Search Button
+        searchButton = new Button();
+        searchButton.Location = new Point(270, 11);
+        searchButton.Size = new Size(75, 25);
+        searchButton.Name = "searchButton";
+        searchButton.Text = "Search";
+        searchButton.Click += SearchButton_Click;
+
+        // PKM Raw TextBox - adjusted position
         pkmRawTextBox = new TextBox();
-        SuspendLayout();
-        // 
-        // pkmRawTextBox
-        // 
-        pkmRawTextBox.Location = new Point(12, 12);
+        pkmRawTextBox.Location = new Point(12, 45);
         pkmRawTextBox.Multiline = true;
         pkmRawTextBox.Name = "pkmRawTextBox";
         pkmRawTextBox.ReadOnly = true;
         pkmRawTextBox.ScrollBars = ScrollBars.Vertical;
-        pkmRawTextBox.Size = new Size(776, 426);
+        pkmRawTextBox.Size = new Size(776, 393);
         pkmRawTextBox.TabIndex = 0;
-        // 
-        // RawViewer
-        // 
+
+        // Form
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
         AutoSize = true;
         ClientSize = new Size(800, 450);
+        Controls.Add(searchLabel);
+        Controls.Add(searchBox);
+        Controls.Add(searchButton);
         Controls.Add(pkmRawTextBox);
         FormBorderStyle = FormBorderStyle.FixedSingle;
         Icon = (Icon)resources.GetObject("$this.Icon");
@@ -60,7 +98,8 @@ partial class RawViewer
         PerformLayout();
     }
 
-    #endregion
-
+    /// <summary>
+    /// The text box that displays the raw Pokemon data.
+    /// </summary>
     private TextBox pkmRawTextBox;
 }

--- a/PKMRaw/RawViewer.cs
+++ b/PKMRaw/RawViewer.cs
@@ -4,24 +4,106 @@ using System.Reflection;
 
 namespace PKMRaw;
 
-/// <inheritdoc/>
+/// <summary>
+/// A form that displays Pokemon data in a raw JSON format with search capabilities.
+/// </summary>
 public partial class RawViewer : Form
 {
-    #region Constructors
+    /// <summary>
+    /// Stores the original JSON text before any search filtering.
+    /// </summary>
+    private readonly string originalText;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RawViewer"/> class.
     /// </summary>
-    /// <param name="pokéMon">
-    /// The input <see cref="PKM"/> instance
-    /// to be shown in JSON format.
-    /// </param>
+    /// <param name="pokéMon">The Pokemon data to display in the viewer.</param>
     public RawViewer(PKM pokéMon)
     {
         InitializeComponent();
         Text = GetWindowText(pokéMon);
-        pkmRawTextBox.Text = SerializePKM(pokéMon);
+        originalText = SerializePKM(pokéMon);
+        pkmRawTextBox.Text = originalText;
     }
-    #endregion
+
+    /// <summary>
+    /// Handles the search button click event.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">An EventArgs that contains no event data.</param>
+    private void SearchButton_Click(object sender, EventArgs e)
+    {
+        PerformSearch();
+    }
+
+    /// <summary>
+    /// Handles the key press event in the search box.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">A KeyPressEventArgs that contains the event data.</param>
+    private void SearchBox_KeyPress(object sender, KeyPressEventArgs e)
+    {
+        if (e.KeyChar == (char)Keys.Enter)
+        {
+            e.Handled = true;
+            PerformSearch();
+        }
+    }
+
+    /// <summary>
+    /// Performs the search operation on the Pokemon data.
+    /// </summary>
+    private void PerformSearch()
+    {
+        string searchTerm = searchBox.Text.Trim();
+
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            pkmRawTextBox.Text = originalText;
+            return;
+        }
+
+        try
+        {
+            // Split the text into lines
+            string[] lines = originalText.Split('\n');
+            List<string> matchedLines = new List<string>();
+
+            // Add opening brace
+            matchedLines.Add("{");
+
+            // Search through each line
+            for (int i = 1; i < lines.Length - 1; i++)  // Skip first and last braces
+            {
+                if (lines[i].Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+                {
+                    string line = lines[i].Trim();
+                    // Add comma if not the last matched line
+                    if (!line.EndsWith(","))
+                        line += ",";
+                    matchedLines.Add("  " + line);
+                }
+            }
+
+            // Remove trailing comma from last line if present
+            if (matchedLines.Count > 1)
+            {
+                string lastLine = matchedLines[matchedLines.Count - 1];
+                if (lastLine.EndsWith(","))
+                    matchedLines[matchedLines.Count - 1] = lastLine.TrimEnd(',');
+            }
+
+            // Add closing brace
+            matchedLines.Add("}");
+
+            // Update the textbox with matched lines
+            pkmRawTextBox.Text = string.Join(Environment.NewLine, matchedLines);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Search error: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
 
     #region Private methods
     private static string GetWindowText(PKM pokéMon)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## A simple PKHeX plugin which allows users to vew the currently selected Pokémon data in JSON format.
+## A simple PKHeX plugin which allows users to view the currently selected Pokémon data in JSON format.
 
 ### Future updates:
 - New tab which will display data beautified.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+## A simple PKHeX plugin which allows users to vew the currently selected Pokémon data in JSON format.
+
+### Future updates:
+- New tab which will display data beautified.
+- Text search functionality.
+- PokéMon comparison window.


### PR DESCRIPTION
Add Search Functionality to Raw Pokemon Data Viewer

Added a search box to the top of the Raw Viewer form that allows users to filter through Pokemon data in real-time. Users can search through JSON properties by typing in the search box and pressing Enter or clicking the Search button.

Changes:
- Added search textbox and button to the UI
- Implemented case-insensitive search functionality
- Added XML documentation comments to resolve CS1591 warnings
- Maintains JSON formatting in search results
- Original data is preserved and restored when search is cleared

The search feature helps users quickly find specific Pokemon properties without having to manually scan through all the data.

![image](https://github.com/user-attachments/assets/997af48c-3560-4086-a237-945c91dae5d8)
![image](https://github.com/user-attachments/assets/6e9c987a-7191-4978-ae77-e8d63851a5d7)

